### PR TITLE
Fix path handling in writeEntireFile

### DIFF
--- a/WikidPad/lib/pwiki/StringOps.py
+++ b/WikidPad/lib/pwiki/StringOps.py
@@ -373,7 +373,7 @@ def writeEntireFile(filename, content, textMode=False,
     appropriate for the OS.
     """
     if writeFileMode == WRITE_FILE_MODE_OVERWRITE:
-        f = open(filename, "wb")
+        f = open(pathEnc(filename), "wb")
 
         try:
             if isinstance(content, str):
@@ -431,12 +431,12 @@ def writeEntireFile(filename, content, textMode=False,
     
         tempPath = TempFileSet.createTempFile(content, suffix=suffix, path=basePath,
                 textMode=textMode)
-    
+
         # TODO: What if unlink or rename fails?
-        if os.path.exists(filename):
-            os.unlink(filename)
-    
-        os.rename(tempPath, filename)
+        if os.path.exists(pathEnc(filename)):
+            os.unlink(pathEnc(filename))
+
+        os.rename(pathEnc(tempPath), pathEnc(filename))
 
 
 

--- a/WikidPad/tests/test_stringops.py
+++ b/WikidPad/tests/test_stringops.py
@@ -1,0 +1,33 @@
+import os
+import sys
+import types
+from pathlib import Path
+
+# run from WikidPad directory
+wikidpad_dir = os.path.abspath('.')
+sys.path.append(os.path.join(wikidpad_dir, 'lib'))
+sys.path.append(wikidpad_dir)
+
+# Minimal wx stub required for importing modules
+wx = types.SimpleNamespace()
+wx.OS_WINDOWS_NT = 18
+wx.OS_WINDOWS_9X = 20
+wx.PlatformInfo = ()
+wx.GetOsVersion = staticmethod(lambda: (0,))
+sys.modules['wx'] = wx
+
+from pwiki.StringOps import (
+    writeEntireFile,
+    loadEntireFile,
+    WRITE_FILE_MODE_OVERWRITE,
+)
+
+def test_write_entire_file(tmp_path):
+    target = tmp_path / 'töst.txt'
+    writeEntireFile(str(target), b'hello', writeFileMode=WRITE_FILE_MODE_OVERWRITE)
+    assert loadEntireFile(str(target)) == b'hello'
+
+def test_write_entire_file_safe(tmp_path):
+    target = tmp_path / 'safe_töst.txt'
+    writeEntireFile(str(target), b'world')
+    assert loadEntireFile(str(target)) == b'world'


### PR DESCRIPTION
## Summary
- handle encoded paths when writing files
- move test to package dir

## Testing
- `pytest tests/test_stringops.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tests.helper')*

------
https://chatgpt.com/codex/tasks/task_e_6850f55fbab08328ad9b88a9cd36d5ea