### PR TITLE
Fix literal comparison warnings

### DIFF
--- a/WikidPad/lib/pwiki/StringOps.py
+++ b/WikidPad/lib/pwiki/StringOps.py
@@ -833,11 +833,21 @@ def unescapeForIni(text):
 #     return text.replace(u"\\", u"\\\\").replace("\n", "\\n").\
 #             replace("\r", "\\r")
 
+_UNESCAPE_RE = _re.compile(r"\\(\\|n|r|t|f)")
+
+def _unescape_repl(match):
+    c = match.group(1)
+    return {"n": "\n", "r": "\r", "t": "\t", "f": "\f", "\\": "\\"}[c]
+
 def unescapeWithRe(text):
     """
     Unescape things like \n or \f. Throws exception if unescaping fails
     """
-    return _re.sub("", text, "", 1)
+    res = _UNESCAPE_RE.sub(_unescape_repl, text)
+    if "\\" in res:
+        # remaining backslash means invalid escape sequence
+        raise ValueError("invalid escape sequence in '%s'" % text)
+    return res
 
 
 def re_sub_escape(pattern):

--- a/WikidPad/lib/pwiki/WikiPyparsing.py
+++ b/WikidPad/lib/pwiki/WikiPyparsing.py
@@ -3059,7 +3059,7 @@ class And(ParseExpression, NecessaryRegexProvider):
                     # be appended to the and-regex
                     break
                 
-            if len(result) is 0:
+            if len(result) == 0:
                 return None
             
             self.reFlagsMask = flagsMask

--- a/WikidPad/lib/pwiki/wxHelper.py
+++ b/WikidPad/lib/pwiki/wxHelper.py
@@ -20,11 +20,20 @@ from . import SystemInfo, StringOps
 #     gobject = None
 
 
+_UNESCAPE_RE = re.compile(r"\\(\\|n|r|t|f)")
+
+def _unescape_repl(match):
+    c = match.group(1)
+    return {"n": "\n", "r": "\r", "t": "\t", "f": "\f", "\\": "\\"}[c]
+
 def _unescapeWithRe(text):
     """
     Unescape things like \n or \f. Throws exception if unescaping fails
     """
-    return re.sub("", text, "", 1)
+    res = _UNESCAPE_RE.sub(_unescape_repl, text)
+    if "\\" in res:
+        raise ValueError("invalid escape sequence in '%s'" % text)
+    return res
 
 
 

--- a/WikidPad/lib/whoosh/codec/whoosh3.py
+++ b/WikidPad/lib/whoosh/codec/whoosh3.py
@@ -1043,7 +1043,7 @@ class W3LeafMatcher(LeafMatcher):
         vs = self._data[2]
         if fixedsize is None or fixedsize < 0:
             self._values = vs
-        elif fixedsize is 0:
+        elif fixedsize == 0:
             self._values = (None,) * self._blocklength
         else:
             assert isinstance(vs, bytes_type)


### PR DESCRIPTION
## Summary
- fix Python literal comparison checks in `WikiPyparsing` and Whoosh codec
- add proper escape handling for `StringOps.unescapeWithRe`

## Testing
- `python3 -m py_compile WikidPad/lib/pwiki/StringOps.py WikidPad/lib/pwiki/wxHelper.py`

------
https://chatgpt.com/codex/tasks/task_e_68512a2203808328b43d026be1aefb9c