### PR TITLE
Fix test helper imports

### DIFF
--- a/WikidPad/tests/test_MediaWikiParser.py
+++ b/WikidPad/tests/test_MediaWikiParser.py
@@ -15,7 +15,7 @@ wikidpad_dir = os.path.abspath('.')
 sys.path.append(os.path.join(wikidpad_dir, 'lib'))
 sys.path.append(wikidpad_dir)
 
-from tests.helper import MockWikiDocument, NodeFinder, getApp
+from .helper import MockWikiDocument, NodeFinder, getApp
 
 
 LANGUAGE_NAME = 'mediawiki_1'

--- a/WikidPad/tests/test_OverlayParser.py
+++ b/WikidPad/tests/test_OverlayParser.py
@@ -15,7 +15,7 @@ wikidpad_dir = os.path.abspath('.')
 sys.path.append(os.path.join(wikidpad_dir, 'lib'))
 sys.path.append(wikidpad_dir)
 
-from tests.helper import MockWikiDocument, getApp, parse, NodeFinder
+from .helper import MockWikiDocument, getApp, parse, NodeFinder
 
 
 LANGUAGE_NAME = 'wikidpad_overlaid_2_0'

--- a/WikidPad/tests/test_WikiDataManager.py
+++ b/WikidPad/tests/test_WikiDataManager.py
@@ -29,7 +29,7 @@ wikidpad_dir = os.path.abspath('.')
 sys.path.append(wikidpad_dir)
 sys.path.append(os.path.join(wikidpad_dir, 'lib'))
 
-from tests.helper import MockWikiDocument, get_text, TESTS_DIR
+from .helper import MockWikiDocument, get_text, TESTS_DIR
 from Consts import ModifyText
 
 

--- a/WikidPad/tests/test_WikidPadParser.py
+++ b/WikidPad/tests/test_WikidPadParser.py
@@ -38,7 +38,7 @@ wikidpad_dir = os.path.abspath('.')
 sys.path.append(wikidpad_dir)
 sys.path.append(os.path.join(wikidpad_dir, 'lib'))
 
-from tests.helper import (
+from .helper import (
     TESTS_DIR, get_text, parse, MockWikiDocument, getApp,
     WikiWordNotFoundException, NodeFinder, ast_eq)
 


### PR DESCRIPTION
## Summary
- switch test modules to use relative imports for the shared helper module
- document running `StringOps` test with appropriate `PYTHONPATH`

## Testing
- `PYTHONPATH=WikidPad:WikidPad/lib pytest WikidPad/tests/test_stringops.py -q`
- `PYTHONPATH=WikidPad:WikidPad/lib pytest WikidPad/tests -q` *(fails: ModuleNotFoundError: No module named 'wx')*
