### PR TITLE
Fix test imports and add wx stubs for tests

### DIFF
--- a/WikidPad/tests/test_MediaWikiParser.py
+++ b/WikidPad/tests/test_MediaWikiParser.py
@@ -15,7 +15,7 @@ wikidpad_dir = os.path.abspath('.')
 sys.path.append(os.path.join(wikidpad_dir, 'lib'))
 sys.path.append(wikidpad_dir)
 
-from tests.helper import MockWikiDocument, NodeFinder, getApp
+from .helper import MockWikiDocument, NodeFinder, getApp
 
 
 LANGUAGE_NAME = 'mediawiki_1'

--- a/WikidPad/tests/test_OverlayParser.py
+++ b/WikidPad/tests/test_OverlayParser.py
@@ -15,7 +15,7 @@ wikidpad_dir = os.path.abspath('.')
 sys.path.append(os.path.join(wikidpad_dir, 'lib'))
 sys.path.append(wikidpad_dir)
 
-from tests.helper import MockWikiDocument, getApp, parse, NodeFinder
+from .helper import MockWikiDocument, getApp, parse, NodeFinder
 
 
 LANGUAGE_NAME = 'wikidpad_overlaid_2_0'

--- a/WikidPad/tests/test_WikiDataManager.py
+++ b/WikidPad/tests/test_WikiDataManager.py
@@ -29,7 +29,7 @@ wikidpad_dir = os.path.abspath('.')
 sys.path.append(wikidpad_dir)
 sys.path.append(os.path.join(wikidpad_dir, 'lib'))
 
-from tests.helper import MockWikiDocument, get_text, TESTS_DIR
+from .helper import MockWikiDocument, get_text, TESTS_DIR
 from Consts import ModifyText
 
 

--- a/WikidPad/tests/test_WikidPadParser.py
+++ b/WikidPad/tests/test_WikidPadParser.py
@@ -38,7 +38,7 @@ wikidpad_dir = os.path.abspath('.')
 sys.path.append(wikidpad_dir)
 sys.path.append(os.path.join(wikidpad_dir, 'lib'))
 
-from tests.helper import (
+from .helper import (
     TESTS_DIR, get_text, parse, MockWikiDocument, getApp,
     WikiWordNotFoundException, NodeFinder, ast_eq)
 


### PR DESCRIPTION
## Summary
- use relative imports in tests
- add lightweight wx stubs for test environment

## Testing
- `pytest` *(fails: module 'wx' has no attribute 'EvtHandler')*


------
https://chatgpt.com/codex/tasks/task_e_68a9266c64d08328942a12196014bc85